### PR TITLE
Upgrade auth to v2

### DIFF
--- a/capsuleerapp/esi.py
+++ b/capsuleerapp/esi.py
@@ -132,6 +132,7 @@ def _esi(
 
     accepted_arg_count = len(url_format.split("{}")) - 1
     url_format_func = (f"/v{version}/" + url_format).format
+    url_format_func = ("/"+url_format).format
 
     if session_type is SessionType.headers:
         accepted_arg_count += 1  # takes a hidden session argument
@@ -335,7 +336,7 @@ class ESISession(PublicESISession):
 
     async def _get_refresh_token(self, refresh_token):
         async with self._login_session.post(
-            "https://login.eveonline.com/oauth/token",
+            "https://login.eveonline.com/v2/oauth/token",
             data={"grant_type": "refresh_token", "refresh_token": refresh_token},
         ) as resp:
             data = await resp.json()

--- a/capsuleerapp/esi.py
+++ b/capsuleerapp/esi.py
@@ -132,7 +132,7 @@ def _esi(
 
     accepted_arg_count = len(url_format.split("{}")) - 1
     url_format_func = (f"/v{version}/" + url_format).format
-    url_format_func = ("/"+url_format).format
+    # url_format_func = ("/"+url_format).format
 
     if session_type is SessionType.headers:
         accepted_arg_count += 1  # takes a hidden session argument

--- a/capsuleerapp/esi.py
+++ b/capsuleerapp/esi.py
@@ -482,4 +482,4 @@ class ESISession(PublicESISession):
 
 
 def get_character(claims) -> tuple[Character, str]:
-    return (Character(int(claims["sub"][14:]), claims["name"]), claims["owner"])
+    return (Character(int(claims["sub"].replace("CHARACTER:EVE:", "")), claims["name"]), claims["owner"])

--- a/capsuleerapp/jwt.py
+++ b/capsuleerapp/jwt.py
@@ -1,0 +1,89 @@
+import requests
+import time
+
+import jwt
+
+METADATA_URL = "https://login.eveonline.com/.well-known/oauth-authorization-server"
+METADATA_CACHE_TIME = 300  # 5 minutes
+ACCEPTED_ISSUERS = ("logineveonline.com", "https://login.eveonline.com")
+EXPECTED_AUDIENCE = "EVE Online"
+
+# We don't want to fetch the jwks data on every request, so we cache it for a short period
+jwks_metadata = None
+jwks_metadata_ttl = 0
+
+
+def fetch_jwks_metadata():
+    """
+    Fetches the JWKS metadata from the SSO server.
+
+    :returns: The JWKS metadata
+    """
+    global jwks_metadata, jwks_metadata_ttl
+    if jwks_metadata is None or jwks_metadata_ttl < time.time():
+        resp = requests.get(METADATA_URL)
+        resp.raise_for_status()
+        metadata = resp.json()
+
+        jwks_uri = metadata["jwks_uri"]
+
+    return jwks_uri
+
+
+def validate_jwt_token(token):
+    """
+    Validates a JWT Token.
+
+    :param str token: The JWT token to validate
+    :returns: The content of the validated JWT access token
+    :raises ExpiredSignatureError: If the token has expired
+    :raises JWTError: If the token is invalid
+    """
+    # url = "https://dev-87evx9ru.auth0.com/.well-known/jwks.json"
+
+    optional_custom_headers = {"User-agent": "custom-user-agent"}
+
+    jwks_client = jwt.PyJWKClient(fetch_jwks_metadata(), headers=optional_custom_headers)
+
+    signing_key = jwks_client.get_signing_key_from_jwt(token)
+
+    # metadata = fetch_jwks_metadata()
+    # keys = metadata["keys"]
+    # Fetch the key algorithm and key idfentifier from the token header
+    header = jwt.get_unverified_header(token)
+    # key = [
+    #     item
+    #     for item in keys
+    #     if item["kid"] == header["kid"] and item["alg"] == header["alg"]
+    # ].pop()
+    return jwt.decode(
+        token,
+        key=signing_key,
+        algorithms=header["alg"],
+        issuer=ACCEPTED_ISSUERS,
+        audience=EXPECTED_AUDIENCE,
+    )
+
+
+def is_token_valid(client_id, token):
+    """
+    Simple check if the token is valid or not.
+
+    :returns: True if the token is valid, False otherwise
+    """
+    try:
+        claims = validate_jwt_token(token)
+        # If our client_id is in the audience list, the token is valid, otherwise, we got a token for another client.
+        return client_id in claims["aud"], claims
+    except jwt.ExpiredSignatureError:
+        print("JWT has expired")
+        return False, None
+    except jwt.InvalidSignatureError:
+        print("Invalid signature")
+        return False, None
+    except jwt.InvalidTokenError:
+        print("Invalid token")
+        return False, None
+    except Exception:
+        # Something went wrong
+        return False, None

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "react-dom": "18.3.1",
         "typescript": "5.6.2",
         "webpack": "^5.95.0",
-        "webpack-cli": "5.1.4",
+        "webpack-cli": "^5.1.4",
         "webpack-merge": "6.0.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-dom": "18.3.1",
     "typescript": "5.6.2",
     "webpack": "^5.95.0",
-    "webpack-cli": "5.1.4",
+    "webpack-cli": "^5.1.4",
     "webpack-merge": "6.0.1"
   }
 }

--- a/pixi.lock
+++ b/pixi.lock
@@ -80,6 +80,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py313h80202fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       - pypi: https://files.pythonhosted.org/packages/13/81/a9ff9032bbe7632fce8812487efe32cee3c76bc0b3221561cd5b6954d876/aiohttp_session-2.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
@@ -233,14 +234,20 @@ packages:
   purls: []
   size: 157088
   timestamp: 1734208393264
+- pypi: https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl
+  name: cachetools
+  version: 5.5.2
+  sha256: d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a
+  requires_python: '>=3.7'
 - pypi: ./
   name: capsuleerapp
   version: '1'
-  sha256: fb29c0744d5a200b640220982306eec804f8e1dbec9aec271ea3c5b75240a39c
+  sha256: 453056b3a0057b34dbbeb8ab2cbf020644cb1e3b4ee68a7c7eb716423e56da42
   requires_dist:
   - aiohttp-session>2.11,<3
   - requests>=2.32.3,<3
-  - pyjwt
+  - pyjwt>=2.10.1,<3
+  - cachetools
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
   sha256: 048c16a9cbcb1fbad02083414d3bc7c1d0eea4b39aee6aa6bf8d1d5089ca8bad

--- a/pixi.lock
+++ b/pixi.lock
@@ -80,13 +80,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py313h80202fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       - pypi: https://files.pythonhosted.org/packages/13/81/a9ff9032bbe7632fce8812487efe32cee3c76bc0b3221561cd5b6954d876/aiohttp_session-2.12.1-py3-none-any.whl
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
-  arch: x86_64
-  platform: linux
   license: None
   purls: []
   size: 2562
@@ -100,8 +101,6 @@ packages:
   - libgomp >=7.5.0
   constrains:
   - openmp_impl 9999
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -133,8 +132,6 @@ packages:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - yarl >=1.17.0,<2.0
-  arch: x86_64
-  platform: linux
   license: MIT AND Apache-2.0
   license_family: Apache
   purls:
@@ -184,8 +181,6 @@ packages:
   - libgcc >=13
   - python >=3.13.0rc2,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls:
@@ -214,8 +209,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - libbrotlicommon 1.1.0 hb9d3cd8_2
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -228,8 +221,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
@@ -238,18 +229,18 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.12.14-hbcca054_0.conda
   sha256: 1afd7274cbc9a334d6d0bc62fa760acc7afdaceb0b91a8df370ec01fd75dc7dd
   md5: 720523eb0d6a9b0f6120c16b2aa4e7de
-  arch: x86_64
-  platform: linux
   license: ISC
   purls: []
   size: 157088
   timestamp: 1734208393264
-- pypi: .
+- pypi: ./
   name: capsuleerapp
   version: '1'
-  sha256: af397115e4e66123fa75ff879847206a0b5e43402e7d588fac82236f7aba717e
+  sha256: fb29c0744d5a200b640220982306eec804f8e1dbec9aec271ea3c5b75240a39c
   requires_dist:
   - aiohttp-session>2.11,<3
+  - requests>=2.32.3,<3
+  - pyjwt
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
   sha256: 048c16a9cbcb1fbad02083414d3bc7c1d0eea4b39aee6aa6bf8d1d5089ca8bad
@@ -271,8 +262,6 @@ packages:
   - pycparser
   - python >=3.13.0rc1,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -290,6 +279,11 @@ packages:
   - pkg:pypi/cfgv?source=hash-mapping
   size: 12973
   timestamp: 1734267180483
+- pypi: https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: charset-normalizer
+  version: 3.4.2
+  sha256: 6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
@@ -313,8 +307,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   purls:
@@ -360,8 +352,6 @@ packages:
   - libgcc >=13
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -410,8 +400,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -458,8 +446,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   constrains:
   - binutils_impl_linux-64 2.43
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -473,8 +459,6 @@ packages:
   - libgcc >=13
   constrains:
   - expat 2.6.4.*
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -485,8 +469,6 @@ packages:
   md5: d645c6d2ac96843a2bfaccd2d62b3ac3
   depends:
   - libgcc-ng >=9.4.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -501,8 +483,6 @@ packages:
   constrains:
   - libgomp 14.2.0 h77fa898_1
   - libgcc-ng ==14.2.0=*_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -513,8 +493,6 @@ packages:
   md5: e39480b9ca41323497b05492a63bc35b
   depends:
   - libgcc 14.2.0 h77fa898_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -525,8 +503,6 @@ packages:
   md5: cc3573974587f12dda90d96e3e55a702
   depends:
   - _libgcc_mutex 0.1 conda_forge
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -538,8 +514,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: 0BSD
   purls: []
   size: 111132
@@ -550,8 +524,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -564,8 +536,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: linux
   license: Unlicense
   purls: []
   size: 873551
@@ -575,8 +545,6 @@ packages:
   md5: 234a5554c53625688d51062645337328
   depends:
   - libgcc 14.2.0 h77fa898_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -587,8 +555,6 @@ packages:
   md5: 8371ac6457591af2cf6159439c1fd051
   depends:
   - libstdcxx 14.2.0 hc0a3c3a_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -599,8 +565,6 @@ packages:
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -612,8 +576,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -627,8 +589,6 @@ packages:
   - libgcc >=13
   constrains:
   - zlib 1.3.1 *_2
-  arch: x86_64
-  platform: linux
   license: Zlib
   license_family: Other
   purls: []
@@ -642,8 +602,6 @@ packages:
   - libgcc >=13
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -656,8 +614,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: X11 AND BSD-3-Clause
   purls: []
   size: 889086
@@ -686,8 +642,6 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.3.2,<4.0a0
   - zlib
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -700,8 +654,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -764,8 +716,6 @@ packages:
   - libgcc >=13
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -783,6 +733,25 @@ packages:
   purls: []
   size: 110100
   timestamp: 1733195786147
+- pypi: https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl
+  name: pyjwt
+  version: 2.10.1
+  sha256: dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
+  requires_dist:
+  - cryptography>=3.4.0 ; extra == 'crypto'
+  - coverage[toml]==5.0.4 ; extra == 'dev'
+  - cryptography>=3.4.0 ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - pytest>=6.0.0,<7.0.0 ; extra == 'dev'
+  - sphinx ; extra == 'dev'
+  - sphinx-rtd-theme ; extra == 'dev'
+  - zope-interface ; extra == 'dev'
+  - sphinx ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - zope-interface ; extra == 'docs'
+  - coverage[toml]==5.0.4 ; extra == 'tests'
+  - pytest>=6.0.0,<7.0.0 ; extra == 'tests'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac
@@ -836,8 +805,6 @@ packages:
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   purls: []
   size: 33263183
@@ -848,8 +815,6 @@ packages:
   md5: 381bbd2a92c863f640a55b6ff3c35161
   constrains:
   - python 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -864,8 +829,6 @@ packages:
   - python >=3.13.0rc1,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -878,13 +841,23 @@ packages:
   depends:
   - libgcc-ng >=12
   - ncurses >=6.3,<7.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
   size: 281456
   timestamp: 1679532220005
+- pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
+  name: requests
+  version: 2.32.3
+  sha256: 70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+  requires_dist:
+  - charset-normalizer>=2,<4
+  - idna>=2.5,<4
+  - urllib3>=1.21.1,<3
+  - certifi>=2017.4.17
+  - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
+  - chardet>=3.0.2,<6 ; extra == 'use-chardet-on-py3'
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.9-py313h890c02e_0.conda
   sha256: 92c060204d737380fd13df9e72e9c0e10dab23ec083b76498d8aa6df5da3c12d
   md5: a99d0cc28fb43c60833b7ae141fc0eea
@@ -894,8 +867,6 @@ packages:
   - libstdcxx >=13
   - python >=3.13.0rc3,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -932,8 +903,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<2.0.0a0
-  arch: x86_64
-  platform: linux
   license: TCL
   license_family: BSD
   purls: []
@@ -967,8 +936,6 @@ packages:
   - libstdcxx >=13
   - python >=3.13.0rc1,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -1009,8 +976,6 @@ packages:
   md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
   depends:
   - libgcc-ng >=9.4.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -1027,8 +992,6 @@ packages:
   - propcache >=0.2.1
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls:
@@ -1042,8 +1005,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib 1.3.1 hb9d3cd8_2
-  arch: x86_64
-  platform: linux
   license: Zlib
   license_family: Other
   purls: []
@@ -1060,8 +1021,6 @@ packages:
   - python_abi 3.13.* *_cp313
   - zstd >=1.5.6,<1.5.7.0a0
   - zstd >=1.5.6,<1.6.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls:
@@ -1075,8 +1034,6 @@ packages:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<2.0.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "capsuleerapp"
 version = "1"
-dependencies = ["aiohttp-session>2.11,<3"]
+dependencies = ["aiohttp-session>2.11,<3", "requests>=2.32.3,<3", "pyjwt>=2.10.1,<3"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "capsuleerapp"
 version = "1"
-dependencies = ["aiohttp-session>2.11,<3", "requests>=2.32.3,<3", "pyjwt>=2.10.1,<3"]
+dependencies = ["aiohttp-session>2.11,<3", "requests>=2.32.3,<3", "pyjwt>=2.10.1,<3", "cachetools>=5.5.2,<6"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Per request on the homepage for help!

I have this working locally, although I didn't bother with the market character -- I don't think that should be particularly affected by this change.

Once I had core auth working, I was surprised at getting 404s from ESI ... when the "same" requests via swagger or locally were fine. The difference _for me_ seemed to be the addition of `/v{n}/`, so I cut that out and let ESI just handle everything via `latest`. But since it seems like both *should* work, I'm a little confused and can revert this change.

Mostly out of laziness and to stick with the official docs on JWK stuff I left the use of the library `requests` in, although it's only used for a single query. Probably it's cleaner to use the existing library you're using for http requests. Of the other two added deps: `pyJWT` is strictly necessary of course; `cachetools` isn't necessary, but why not use the standard tool for this instead of rolling your own?

Lastly, I noticed these code paths aren't tested (since the existing tests don't break) -- but test coverage is low across the board. That means my confidence that these changes are correct for the general case low!